### PR TITLE
Use Hill notation convention

### DIFF
--- a/atmodeller/interfaces.py
+++ b/atmodeller/interfaces.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
-from molmass import Formula
+from molmass import Composition, Formula
 
 from atmodeller.activity.interfaces import ActivityProtocol, ConstantActivity
 from atmodeller.thermodata.interfaces import (
@@ -78,37 +78,35 @@ class ChemicalSpecies:
         assert thermodata is not None
         self._thermodata: ThermodynamicDataForSpeciesProtocol = thermodata
         logger.info(
-            "Creating %s %s (hill formula=%s) using thermodynamic data in %s",
+            "Creating %s for %s using thermodynamic data in %s",
             self.__class__.__name__,
-            self.formula,
             self.hill_formula,
             self.thermodata.data_source,
         )
 
+    def composition(self, isotopic: bool = False) -> Composition:
+        """Composition of the species"""
+        return self._formula.composition(isotopic)
+
     @property
     def elements(self) -> list[str]:
         """Elements in species"""
-        return list(self.formula.composition().keys())
-
-    @property
-    def formula(self) -> Formula:
-        """Formula object"""
-        return self._formula
+        return list(self.composition().keys())
 
     @property
     def hill_formula(self) -> str:
         """Hill formula"""
-        return self.formula.formula
+        return self._formula.formula
 
     @property
     def molar_mass(self) -> float:
         r"""Molar mass in :math:\mathrm{kg}\mathrm{mol}^{-1}"""
-        return UnitConversion.g_to_kg(self.formula.mass)
+        return UnitConversion.g_to_kg(self._formula.mass)
 
     @property
     def name(self) -> str:
-        """Unique name by combining formula and phase"""
-        return f"{self.formula}_{self.phase}"
+        """Unique name by combining Hill notation and phase"""
+        return f"{self.hill_formula}_{self.phase}"
 
     @property
     def phase(self) -> str:

--- a/atmodeller/interior_atmosphere.py
+++ b/atmodeller/interior_atmosphere.py
@@ -531,7 +531,7 @@ class InteriorAtmosphereSystem:
     def log10_fugacity_coefficients_dict(self) -> dict[str, float]:
         """Fugacity coefficients (relevant for gas species only) in a dictionary"""
         output: dict[str, float] = {
-            str(species.formula): np.log10(
+            str(species.hill_formula): np.log10(
                 species.eos.fugacity_coefficient(
                     temperature=self.planet.surface_temperature, pressure=self.total_pressure
                 )
@@ -546,7 +546,7 @@ class InteriorAtmosphereSystem:
         output: dict[str, float] = {}
         for key, value in self.log10_fugacity_coefficients_dict.items():
             # TODO: Not clean to append _g suffix to denote gas phase.
-            output[f"f{key}"] = 10 ** (np.log10(self.solution_dict()[f"{key}_g"]) + value)
+            output[key] = 10 ** (np.log10(self.solution_dict()[f"{key}_g"]) + value)
 
         return output
 

--- a/atmodeller/output.py
+++ b/atmodeller/output.py
@@ -420,9 +420,9 @@ class Output(UserDict):
 
         for species in interior_atmosphere.species.gas_species.values():
             pressure: float = interior_atmosphere.solution_dict()[species.name]
-            fugacity: float = interior_atmosphere.fugacities_dict[f"f{species.formula}"]
+            fugacity: float = interior_atmosphere.fugacities_dict[species.hill_formula]
             fugacity_coefficient: float = (
-                10 ** interior_atmosphere.log10_fugacity_coefficients_dict[str(species.formula)]
+                10 ** interior_atmosphere.log10_fugacity_coefficients_dict[species.hill_formula]
             )
             volume_mixing_ratio: float = pressure / interior_atmosphere.total_pressure
 

--- a/atmodeller/solubility/interfaces.py
+++ b/atmodeller/solubility/interfaces.py
@@ -63,7 +63,7 @@ class Solubility(ABC):
             temperature: Temperature in K. Defaults to None.
             pressure: Total pressure in bar. Defaults to None.
             **kwargs: Arbitrary keyword arguments. Keyword arguments that are fugacities must
-                adhere to the naming convention: fO2, fH2, fH2O, etc.
+                adhere to Hill notation: O2, H2, H2O, O2S, etc.
 
         Returns:
             Dissolved volatile concentration in the melt in ppmw

--- a/atmodeller/solubility/other_species.py
+++ b/atmodeller/solubility/other_species.py
@@ -108,7 +108,7 @@ class N2_basalt_bernadou(Solubility):
 
     @override
     def concentration(
-        self, fugacity: float, *, temperature: float, pressure: float, fO2: float, **kwargs
+        self, fugacity: float, *, temperature: float, pressure: float, O2: float, **kwargs
     ) -> float:
         del kwargs
         k13: float = np.exp(
@@ -117,7 +117,7 @@ class N2_basalt_bernadou(Solubility):
         k14: float = np.exp(
             -(183733 + 172 * temperature - 5 * pressure) / (GAS_CONSTANT * temperature)
         )
-        molfrac: float = (k13 * fugacity) + ((fO2 ** (-3 / 4)) * k14 * (fugacity**0.5))
+        molfrac: float = (k13 * fugacity) + ((O2 ** (-3 / 4)) * k14 * (fugacity**0.5))
         ppmw: float = UnitConversion.fraction_to_ppm(molfrac)
 
         return ppmw
@@ -146,7 +146,7 @@ class N2_basalt_dasgupta(Solubility):
 
     @override
     def concentration(
-        self, fugacity: float, *, temperature: float, pressure: float, fO2: float, **kwargs
+        self, fugacity: float, *, temperature: float, pressure: float, O2: float, **kwargs
     ) -> float:
         del kwargs
         fugacity_gpa: float = UnitConversion.bar_to_GPa(fugacity)
@@ -157,7 +157,7 @@ class N2_basalt_dasgupta(Solubility):
             + 0.055 * (pressure - 1) / temperature
             - 0.8853 * np.log(temperature)
         )
-        fo2_shift = np.log10(fO2) - logiw_fugacity
+        fo2_shift = np.log10(O2) - logiw_fugacity
         ppmw: float = (fugacity_gpa**0.5) * np.exp(
             (5908.0 * (pressure_gpa**0.5) / temperature) - (1.6 * fo2_shift)
         )
@@ -179,10 +179,10 @@ class N2_basalt_libourel(Solubility):
         self._power_law: SolubilityPowerLaw = SolubilityPowerLaw(constant=0.0611, exponent=1)
 
     @override
-    def concentration(self, fugacity: float, *, fO2: float, **kwargs) -> float:
+    def concentration(self, fugacity: float, *, O2: float, **kwargs) -> float:
         del kwargs
         ppmw: float = self._power_law.concentration(fugacity)
-        constant: float = (fO2**-0.75) * 5.97e-10
+        constant: float = (O2**-0.75) * 5.97e-10
         power_law: SolubilityPowerLaw = SolubilityPowerLaw(constant=constant, exponent=0.5)
         ppmw += power_law.concentration(fugacity)
 

--- a/atmodeller/solubility/sulfur_species.py
+++ b/atmodeller/solubility/sulfur_species.py
@@ -46,11 +46,11 @@ class S2_sulfate_andesite_boulliung(Solubility):
     """
 
     @override
-    def concentration(self, fugacity: float, *, temperature: float, fO2: float, **kwargs) -> float:
+    def concentration(self, fugacity: float, *, temperature: float, O2: float, **kwargs) -> float:
         # Fugacity is fS2
         del kwargs
         logcs: float = -12.948 + (31586.2393 / temperature)
-        logs_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(fO2))
+        logs_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(O2))
         s_wtp: float = 10**logs_wtp
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
 
@@ -66,10 +66,10 @@ class S2_sulfide_andesite_boulliung(Solubility):
     """
 
     @override
-    def concentration(self, fugacity: float, *, temperature: float, fO2: float, **kwargs) -> float:
+    def concentration(self, fugacity: float, *, temperature: float, O2: float, **kwargs) -> float:
         del kwargs
         logcs: float = 0.225 - (8921.0927 / temperature)
-        logs_wtp: float = logcs - (0.5 * (np.log10(fO2) - np.log10(fugacity)))
+        logs_wtp: float = logcs - (0.5 * (np.log10(O2) - np.log10(fugacity)))
         s_wtp: float = 10**logs_wtp
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
 
@@ -89,14 +89,12 @@ class S2_andesite_boulliung(Solubility):
         fugacity: float,
         *,
         temperature: float,
-        fO2: float,
+        O2: float,
         **kwargs,
     ) -> float:
         del kwargs
-        concentration: float = self.sulfide.concentration(
-            fugacity, temperature=temperature, fO2=fO2
-        )
-        concentration += self.sulfate.concentration(fugacity, temperature=temperature, fO2=fO2)
+        concentration: float = self.sulfide.concentration(fugacity, temperature=temperature, O2=O2)
+        concentration += self.sulfate.concentration(fugacity, temperature=temperature, O2=O2)
 
         return concentration
 
@@ -111,11 +109,11 @@ class S2_sulfate_basalt_boulliung(Solubility):
     """
 
     @override
-    def concentration(self, fugacity: float, *, temperature: float, fO2: float, **kwargs) -> float:
+    def concentration(self, fugacity: float, *, temperature: float, O2: float, **kwargs) -> float:
         # Fugacity is fS2
         del kwargs
         logcs: float = -12.948 + (32333.5635 / temperature)
-        logso4_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(fO2))
+        logso4_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(O2))
         so4_wtp: float = 10**logso4_wtp
         s_wtp: float = so4_wtp * (32.065 / 96.06)
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
@@ -132,11 +130,11 @@ class S2_sulfide_basalt_boulliung(Solubility):
     """
 
     @override
-    def concentration(self, fugacity: float, *, temperature: float, fO2: float, **kwargs) -> float:
+    def concentration(self, fugacity: float, *, temperature: float, O2: float, **kwargs) -> float:
         # Fugacity is fS2
         del kwargs
         logcs: float = 0.225 - (8045.7465 / temperature)
-        logs_wtp: float = logcs - (0.5 * (np.log10(fO2) - np.log10(fugacity)))
+        logs_wtp: float = logcs - (0.5 * (np.log10(O2) - np.log10(fugacity)))
         s_wtp: float = 10**logs_wtp
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
 
@@ -158,15 +156,15 @@ class S2_basalt_boulliung(Solubility):
         fugacity: float,
         *,
         temperature: float,
-        fO2: float,
+        O2: float,
         **kwargs,
     ) -> float:
         del kwargs
         concentration: float = self.sulfide_solubility.concentration(
-            fugacity, temperature=temperature, fO2=fO2
+            fugacity, temperature=temperature, O2=O2
         )
         concentration += self.sulfate_solubility.concentration(
-            fugacity, temperature=temperature, fO2=fO2
+            fugacity, temperature=temperature, O2=O2
         )
 
         return concentration
@@ -187,13 +185,13 @@ class S2_sulfate_trachybasalt_boulliung(Solubility):
         fugacity: float,
         *,
         temperature: float,
-        fO2: float,
+        O2: float,
         **kwargs,
     ) -> float:
         # Fugacity is fS2
         del kwargs
         logcs: float = -12.948 + (32446.366 / temperature)
-        logs_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(fO2))
+        logs_wtp: float = logcs + (0.5 * np.log10(fugacity)) + (1.5 * np.log10(O2))
         s_wtp: float = 10**logs_wtp
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
 
@@ -214,13 +212,13 @@ class S2_sulfide_trachybasalt_boulliung(Solubility):
         fugacity: float,
         *,
         temperature: float,
-        fO2: float,
+        O2: float,
         **kwargs,
     ) -> float:
         # Fugacity is fS2
         del kwargs
         logcs: float = 0.225 - (7842.5 / temperature)
-        logs_wtp: float = logcs - (0.5 * (np.log10(fO2) - np.log10(fugacity)))
+        logs_wtp: float = logcs - (0.5 * (np.log10(O2) - np.log10(fugacity)))
         s_wtp: float = 10**logs_wtp
         ppmw: float = UnitConversion.weight_percent_to_ppmw(s_wtp)
 
@@ -248,7 +246,7 @@ class S_mercury_magma_namur(Solubility):
         fugacity: float,
         *,
         temperature: float,
-        fO2: float,
+        O2: float,
         **kwargs,
     ) -> float:
         del kwargs
@@ -256,7 +254,7 @@ class S_mercury_magma_namur(Solubility):
             self.coefficients[0]
             + (self.coefficients[1] / temperature)
             + ((self.coefficients[2] * fugacity) / temperature)
-            + (self.coefficients[3] * np.log10(fO2))
+            + (self.coefficients[3] * np.log10(O2))
             - 0.136
         )
         ppmw: float = UnitConversion.weight_percent_to_ppmw(wt_perc)

--- a/atmodeller/thermodata/combine.py
+++ b/atmodeller/thermodata/combine.py
@@ -85,4 +85,6 @@ class ThermodynamicDatasetCombined(ThermodynamicDataset):
             if dataset is not None:
                 return dataset.get_species_data(species, **kwargs)
 
-        raise KeyError(f"Thermodynamic data for {species.formula} is not available in any dataset")
+        raise KeyError(
+            f"Thermodynamic data for {species.hill_formula} not available in any dataset"
+        )

--- a/atmodeller/thermodata/holland.py
+++ b/atmodeller/thermodata/holland.py
@@ -100,12 +100,12 @@ class ThermodynamicDatasetHollandAndPowell(ThermodynamicDataset):
             Thermodynamic data for the species or None if not available
         """
         del kwargs
-        search_name: str = name if name is not None else str(species.formula)
+        search_name: str = name if name is not None else species.hill_formula
 
         try:
             logger.info(
-                "Searching for %s (name=%s) in %s",
-                species.formula,
+                "Searching for %s (name = %s) in %s",
+                species.hill_formula,
                 search_name,
                 self.data_source,
             )
@@ -161,8 +161,8 @@ class ThermodynamicDatasetHollandAndPowell(ThermodynamicDataset):
                 gibbs += self._get_volume_pressure_integral(temperature, pressure)
 
             logger.debug(
-                "Species = %s, standard Gibbs energy of formation=%f",
-                self.species.formula,
+                "Species = %s, standard Gibbs energy of formation = %f",
+                self.species.hill_formula,
                 gibbs,
             )
 

--- a/atmodeller/thermodata/janaf.py
+++ b/atmodeller/thermodata/janaf.py
@@ -46,7 +46,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def is_homonuclear_diatomic(species: ChemicalSpecies) -> bool:
     """True if species is homonuclear diatomic, otherwise False."""
-    composition: Composition = species.formula.composition()
+    composition: Composition = species.composition()
     if len(list(composition.keys())) == 1 and list(composition.values())[0].count == 2:
         return True
     else:
@@ -114,8 +114,7 @@ class ThermodynamicDatasetJANAF(ThermodynamicDataset):
             """
             try:
                 logger.info(
-                    "Searching for %s (formula=%s, name=%s, phase=%s) in %s",
-                    species.formula,
+                    "Searching for %s (name = %s, phase = %s) in %s",
                     species.hill_formula,
                     name,
                     phases[0],
@@ -136,8 +135,8 @@ class ThermodynamicDatasetJANAF(ThermodynamicDataset):
         # First, check exclusively for a filename match if a filename has been specified.
         if filename is not None:
             logger.info(
-                "Searching for %s (filename=%s) in %s",
-                species.formula,
+                "Searching for %s (filename = %s) in %s",
+                species.hill_formula,
                 filename,
                 self.data_source,
             )
@@ -197,8 +196,8 @@ class ThermodynamicDatasetJANAF(ThermodynamicDataset):
             gibbs: float = self.data.DeltaG(temperature) * kilo
 
             logger.debug(
-                "Species=%s, standard Gibbs energy of formation=%f",
-                self.species.formula,
+                "Species = %s, standard Gibbs energy of formation = %f",
+                self.species.hill_formula,
                 gibbs,
             )
 

--- a/tests/test_CHO_ideal.py
+++ b/tests/test_CHO_ideal.py
@@ -380,11 +380,11 @@ def test_H_and_C_hill_formula() -> None:
     system: InteriorAtmosphereSystem = InteriorAtmosphereSystem(species=species, planet=planet)
 
     target: dict[str, float] = {
-        "OH2_g": 0.25824358142493425,
+        "H2O_g": 0.25824358142493425,
         "H2_g": 0.2521806525810137,
         "O2_g": 8.740121617121534e-08,
-        "OC_g": 59.6819921102523,
-        "O2C_g": 13.404792068284909,
+        "CO_g": 59.6819921102523,
+        "CO2_g": 13.404792068284909,
     }
 
     system.solve(constraints)

--- a/tests/test_silicon_nonideal.py
+++ b/tests/test_silicon_nonideal.py
@@ -94,7 +94,7 @@ def test_SiHO_massSiH_nosolubility() -> None:
         "O2_g": 8.041858631374242e-05,
         "OSi_g": 297.7208780281457,
         "H4Si_g": 3.8854445389482284,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)
@@ -136,7 +136,7 @@ def test_SiHO_massSiH_solubility() -> None:
         "O2_g": 2.2005226675444582e-05,
         "OSi_g": 569.1471756022945,
         "H4Si_g": 4.292996959380682,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)
@@ -175,7 +175,7 @@ def test_SiHO_massH_logfO2_nosolubility() -> None:
         "O2_g": 0.03382190282100078,
         "OSi_g": 14.517388181293816,
         "H4Si_g": 0.008762061109896661,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)
@@ -214,7 +214,7 @@ def test_SiHO_massH_logfO2_solubility() -> None:
         "O2_g": 0.025481748164747447,
         "OSi_g": 16.72526080495589,
         "H4Si_g": 9.750334904890755e-05,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)
@@ -251,7 +251,7 @@ def test_SiHO_totalpressure_logfO2_nosolubility() -> None:
         "O2_g": 0.02877934211561468,
         "OSi_g": 15.737910722708122,
         "H4Si_g": 0.002384364181797566,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)
@@ -288,7 +288,7 @@ def test_SiHO_fugacityH2O_logfO2_nosolubility() -> None:
         "O2_g": 0.03426380501584421,
         "OSi_g": 14.42346859651946,
         "H4Si_g": 0.00939136258814609,
-        "SiO2_l": 1.0,
+        "O2Si_l": 1.0,
     }
 
     system.solve(constraints)


### PR DESCRIPTION
The user can still specify formula as they wish, but the internals of the code now exclusively use Hill notation, including for output.  The formula/name of the species can still be overridden when specifying which name to search for in the thermodynamic dataset(s).