### PR TITLE
dz/dp for extrapolating real gas EOS

### DIFF
--- a/atmodeller/__init__.py
+++ b/atmodeller/__init__.py
@@ -42,7 +42,7 @@ print("Atmodeller initialized with double precision (float64)")
 # This prevents error_if from throwing an error when encountering NaN or Inf values. To actually
 # find the root cause of NaN or Inf values, you should set this to "raise" or "breakpoint" as per
 # https://docs.kidger.site/equinox/api/errors/
-os.environ["EQX_ON_ERROR"] = "nan"
+os.environ["EQX_ON_ERROR"] = "raise"
 
 # Suppress warnings (notably from Equinox about static JAX arrays)
 if not sys.warnoptions:

--- a/atmodeller/eos/_aggregators.py
+++ b/atmodeller/eos/_aggregators.py
@@ -349,7 +349,7 @@ class UpperBoundRealGas(RealGas):
         Args:
             temperature: Temperature in K
         """
-        return self.real_gas.dzdp(temperature, self.p_eval)
+        return 0.0  # self.real_gas.dzdp(temperature, self.p_eval)
 
     @override
     @eqx.filter_jit


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In relation to #111 , testing revealed that real gas cases struggled to converge when dzdp!=0 for the extrapolated real gas. In particular, the linear solver (lineax) would often fail with Nan/infs reported.  This could relate to the propagation of derivatives, since the value of dzdp itself seems to be OK (finite, albeit sometimes small, down to 1e-12).


* **What is the current behavior?** (You can also link to an open issue here)
Real gas cases struggle or don't converge for certain parameter ranges.  Solver can crash.  The fix proposed in #111 sometimes doesn't work.


* **What is the new behavior (if this is a feature change)?**
dzdp is always assumed zero outside of the calibration range


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Results could change if your cases fell outside the calibration range of one or several EOS included in your model.


* **Other information**:

